### PR TITLE
Add version script for tighter control over symbol visibility

### DIFF
--- a/static-glibc/build.sh
+++ b/static-glibc/build.sh
@@ -15,7 +15,7 @@ ar rcs libmystaticlib.a mystaticlib.o
 echo ""
 echo Building shared lib...
 g++ $compile_flags -c mysharedlib.cpp -o mysharedlib.o
-g++ -shared -static-libgcc -static-libstdc++ mysharedlib.o libmystaticlib.a -o libmysharedlib.so
+g++ -shared -static-libgcc -static-libstdc++ -Wl,--version-script=mysharedlib.vers mysharedlib.o libmystaticlib.a -o libmysharedlib.so
 
 echo Transitive shared lib. dependencies:
 ldd libmysharedlib.so

--- a/static-glibc/mysharedlib.vers
+++ b/static-glibc/mysharedlib.vers
@@ -1,0 +1,6 @@
+{
+global:
+    compute_sum;
+local:
+    *;
+};


### PR DESCRIPTION
This is similar to how module DEF files on Windows can control visibility of exported symbols from a shared library.